### PR TITLE
Fix btn-tab screen overflow

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -1389,6 +1389,7 @@ a.close:hover {
   line-height: 1.2;
   border: solid #f0f0f0;
   border-width: .1rem 0 0 .1rem;
+  float: left;
 }
 
 .btn.btn-tab:hover,


### PR DESCRIPTION
With several btn-tab, the btn-group overflow on the right:
![image](https://user-images.githubusercontent.com/64371/40824424-304f8ef4-6585-11e8-9ba7-b121e1c5a3dc.png)

With a float left on the btn-tab class, all btn-group child are visible on the screen.
![image](https://user-images.githubusercontent.com/64371/40824482-5cc9cfda-6585-11e8-818b-aa0359a58277.png)

Thanks